### PR TITLE
Update quickstart.Rmd

### DIFF
--- a/vignettes/quickstart.Rmd
+++ b/vignettes/quickstart.Rmd
@@ -48,7 +48,7 @@ Now, let's compare solutions in the two portfolios.
 plot(results, results2, i=0, j=0)
 
 # geoplot comparing selection frequencies
-plot(results, results2, basemap='satelliet', alpha=0.4)
+plot(results, results2, basemap='satellite', alpha=0.4)
 ```
 
 The solutions in the second portfolio seem to be better. How can we rank the solutions within this portfolio? Let's make some dotcharts.


### PR DESCRIPTION
The run of the command

    # geoplot comparing selection frequencies
    plot(results, results2, basemap='satelliet', alpha=0.4)

causes the following error:

    Error in match.arg(basemap, c("roadmap", "mobile", "satellite", "terrain",  : 
    'arg' should be one of “roadmap”, “mobile”, “satellite”, “terrain”, “hybrid”, “mapmaker-roadmap”, “mapmaker-hybrid”

The parameter 'satelliet contains a typo, so it has been corrected in 'satellite'.