### PR TITLE
fixed typo in calcPuVsSpeciesData.SpatialPolygons

### DIFF
--- a/R/calcPuVsSpeciesData.R
+++ b/R/calcPuVsSpeciesData.R
@@ -28,7 +28,7 @@ calcPuVsSpeciesData<-function(x, ...) UseMethod("calcPuVsSpeciesData")
 calcPuVsSpeciesData.SpatialPolygons<-function(x,y,ids=seq_len(nlayers(y)), ncores=1, gdal=FALSE, ...) {
 	# check for invalid inputs
 	stopifnot(inherits(y, "Raster"))
-	stopifnot(nlayers(y)!=length(ids))
+	stopifnot(nlayers(y)==length(ids))
 	return(
 		calcPuVsSpeciesData.SpatialPolygonsDataFrame(
 			x=SpatialPolygonsDataFrame(x@polygons, data=data.frame(id=seq_len(nrow(x@data)), row.names=laply(x@polygons, slot, name="ID"))),

--- a/R/calcPuVsSpeciesData.R
+++ b/R/calcPuVsSpeciesData.R
@@ -29,6 +29,7 @@ calcPuVsSpeciesData.SpatialPolygons<-function(x,y,ids=seq_len(nlayers(y)), ncore
 	# check for invalid inputs
 	stopifnot(inherits(y, "Raster"))
 	stopifnot(nlayers(y)==length(ids))
+	return(x@polygons)
 	return(
 		calcPuVsSpeciesData.SpatialPolygonsDataFrame(
 			x=SpatialPolygonsDataFrame(x@polygons, data=data.frame(id=seq_len(nrow(x@data)), row.names=laply(x@polygons, slot, name="ID"))),

--- a/R/calcPuVsSpeciesData.R
+++ b/R/calcPuVsSpeciesData.R
@@ -29,7 +29,6 @@ calcPuVsSpeciesData.SpatialPolygons<-function(x,y,ids=seq_len(nlayers(y)), ncore
 	# check for invalid inputs
 	stopifnot(inherits(y, "Raster"))
 	stopifnot(nlayers(y)==length(ids))
-	return(x@polygons)
 	return(
 		calcPuVsSpeciesData.SpatialPolygonsDataFrame(
 			x=SpatialPolygonsDataFrame(x@polygons, data=data.frame(id=seq_len(nrow(x@data)), row.names=laply(x@polygons, slot, name="ID"))),


### PR DESCRIPTION
calcPuVsSpeciesData.SpatialPolygons should check to ensure that the length of the ids vector is the same as the number of layers in the RasterStack of species. The typo was causing an error to be raised if these lengths were equal.