### PR TITLE
fixed bugs in calcPuVsSpeciesData.SpatialPolygons

### DIFF
--- a/R/calcPuVsSpeciesData.R
+++ b/R/calcPuVsSpeciesData.R
@@ -28,10 +28,10 @@ calcPuVsSpeciesData<-function(x, ...) UseMethod("calcPuVsSpeciesData")
 calcPuVsSpeciesData.SpatialPolygons<-function(x,y,ids=seq_len(nlayers(y)), ncores=1, gdal=FALSE, ...) {
 	# check for invalid inputs
 	stopifnot(inherits(y, "Raster"))
-	stopifnot(nlayers(y)!=length(ids))
+	stopifnot(nlayers(y)==length(ids))
 	return(
 		calcPuVsSpeciesData.SpatialPolygonsDataFrame(
-			x=SpatialPolygonsDataFrame(x@polygons, data=data.frame(id=seq_len(nrow(x@data)), row.names=laply(x@polygons, slot, name="ID"))),
+			x=SpatialPolygonsDataFrame(x, data=data.frame(id=seq_len(length(x)), row.names=laply(x@polygons, slot, name="ID"))),
 			y=y,
 			ids=ids,
 			ncores=ncores,


### PR DESCRIPTION
A couple small bugs in calcPuVsSpeciesData.SpatialPolygons were causing calcPuVsSpeciesData to give an error when passed a SpatialPolygons object, despite it working for SpatialPolygonsDataFrame objects.

[PR from yesterday](https://github.com/paleo13/marxan/pull/16) fixed one of the issues, but missed the others, so I've closed it. With this PR calcPuVsSpeciesData.SpatialPolygons should now work as expected.
